### PR TITLE
Fix anchor navigation for services page sections

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -57,6 +57,23 @@ html {
   overflow-x: hidden;
 }
 
+/* サービスページのアンカー着地位置（固定ヘッダーに隠れないよう余白を確保） */
+#estate,
+#lifetime,
+#cleanup,
+#special,
+#waste,
+#buyback {
+  scroll-margin-top: 100px;
+}
+
+.svc-anchor {
+  display: block;
+  height: 0;
+  margin: 0;
+  visibility: hidden;
+}
+
 body {
   overflow-x: hidden;
   font-family: var(--font-sans);

--- a/privacy.html
+++ b/privacy.html
@@ -153,8 +153,8 @@
             <ul class="footer-menu-list">
               <li><a href="services.html#estate">遺品整理サービス</a></li>
               <li><a href="services.html#lifetime">生前整理サービス</a></li>
-              <li><a href="services.html#special">特殊清掃</a></li>
-              <li><a href="services.html#cleanup">不用品回収</a></li>
+              <li><a href="services.html#cleanup">特殊清掃</a></li>
+              <li><a href="services.html#waste">不用品回収</a></li>
             </ul>
           </div>
           <div class="footer-menu-section">

--- a/services.html
+++ b/services.html
@@ -139,7 +139,8 @@
   </div>
 
   <!-- サービス概要 -->
-  <section class="svc-overview">
+  <section class="svc-overview" id="estate">
+    <span id="lifetime" class="svc-anchor" aria-hidden="true"></span>
     <div class="container">
       <div class="svc-overview-image-board">
         <picture>
@@ -242,7 +243,7 @@
   </section>
 
   <!-- 捨てない片付けセクション -->
-  <section class="svc-nowaste">
+  <section class="svc-nowaste" id="buyback">
     <div class="container">
       <div class="svc-nowaste-header">
         <span class="svc-section-label">SUSTAINABLE</span>
@@ -285,7 +286,9 @@
   </section>
 
   <!-- その他サポート -->
-  <section class="svc-other">
+  <section class="svc-other" id="cleanup">
+    <span id="special" class="svc-anchor" aria-hidden="true"></span>
+    <span id="waste" class="svc-anchor" aria-hidden="true"></span>
     <div class="container">
       <h2 class="svc-other-title">遺品回収の他にもお客様をサポートいたします。</h2>
       <p class="svc-other-sub">「私たちは遺品を整理して終わり」という訳ではありません。<br>遺品整理時に関わることは、まずは「整理のミカタ」にご相談ください。</p>


### PR DESCRIPTION
## Summary
This PR fixes anchor link navigation on the services page to properly account for the fixed header, ensuring sections don't get hidden when users navigate to them.

## Key Changes
- **CSS Updates**: Added `scroll-margin-top: 100px` to all service section anchors (`#estate`, `#lifetime`, `#cleanup`, `#special`, `#waste`, `#buyback`) to create offset space for the fixed header
- **Anchor Implementation**: Introduced `.svc-anchor` utility class for invisible anchor elements that don't affect layout
- **HTML Structure**: 
  - Added `id="estate"` to the main service overview section
  - Added `id="buyback"` to the "捨てない片付け" (no-waste) section
  - Added `id="cleanup"` to the "その他サポート" (other support) section
  - Added hidden anchor spans for `#lifetime`, `#special`, and `#waste` sections using the `.svc-anchor` class
- **Footer Links**: Updated privacy.html footer navigation links to match the corrected anchor IDs (`#cleanup` for 特殊清掃 and `#waste` for 不用品回収)

## Implementation Details
The `.svc-anchor` class uses `display: block`, `height: 0`, `visibility: hidden`, and `margin: 0` to create invisible anchor points that don't affect page layout. This approach allows multiple anchors within a single section while maintaining clean HTML semantics and proper accessibility with `aria-hidden="true"`.

https://claude.ai/code/session_01Fmjc2ZmFFoudsYbPWCd66z